### PR TITLE
fix: travelogue 테이블 내 default_factory 옵션 비정상 작동 수정 #12

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,13 +1,11 @@
-from sqlalchemy import Column, Integer, String, Float, Boolean, ForeignKey, DateTime
-from datetime import datetime
+from sqlalchemy import Column, Integer, String, Float, Boolean, ForeignKey, DateTime, func
 from database import Base
-from sqlalchemy.orm import relationship
 
 class Travelogue(Base):
     __tablename__ = 'travelogue'
     id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
     style_category = Column(Integer)
-    created_at = Column(DateTime, default_factory=datetime.now)
+    created_at = Column(DateTime, server_default=func.now())
 
 
 class Purpose(Base):


### PR DESCRIPTION
## ✨ 작업 개요
- #12


## ✅ 주요 변경 사항
- travelogue 테이블 created_at 컬럼의 default_factory 옵션을 server_default로 변경
- supabase의 timezone을 UTC에서 Asia/Seoul로 변경

---

## 🧪 테스트 방법
- `show timezone` 명령어로 timezone이 설정됐는지 확인
<img src="https://github.com/user-attachments/assets/68b58294-a375-497c-89ad-04909e42cbb0" width=100>

- travelogue POST API를 활용해 튜플을 생성했을 때, 올바르게 현재 시간 (Asia/Seoul)이 삽입되는 지 확인
  - 이미 존재하는 튜플도 timezone에 맞게 시간이 수정되는 것을 확인할 수 있었음
<img src="https://github.com/user-attachments/assets/3710e37c-c3fa-432d-96f6-7b51b290eb69" width=300>

---

## 💬 리뷰 요청 포인트
- 단순 옵션 변경 (코드 두 줄 변경)이고, 정상 작동을 확인했으므로 다음 작업을 위해 바로 PR Accept를 하겠습니다.

close #12 
