### PR TITLE
[기능추가][API] 여행기 튜플 확인 (GET), 생성 (POST), 수정 (PATCH) API 개발

### DIFF
--- a/api_sm.py
+++ b/api_sm.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel, Field
 from datetime import datetime
 from database import SessionLocal
@@ -69,3 +69,19 @@ async def create_travelogue(db: db_dependency):
     db.commit()
     db.refresh(db_travelogue)
     return db_travelogue
+
+
+@router.patch(
+    "/api/travelogue/{travelogue_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="여행기 튜플 수정",
+    description="지정된 여행기의 style_category를 업데이트합니다."
+)
+async def update_travelogue(travelogue_id: int, update: TravelogueUpdate, db: db_dependency):
+    db_travelogue = db.query(Travelogue).filter(Travelogue.id == travelogue_id).first()
+    if not db_travelogue:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail={"error": "Travelogue not found"})
+    db_travelogue.style_category = update.style_category
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/api_sm.py
+++ b/api_sm.py
@@ -1,0 +1,56 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from datetime import datetime
+from database import SessionLocal
+from typing import Annotated, List
+from sqlalchemy.orm import Session
+from models import Travelogue
+from starlette import status
+
+router = APIRouter()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+db_dependency = Annotated[Session, Depends(get_db)]
+
+
+class TravelogueUpdate(BaseModel):
+    style_category: int = Field(ge=1, le=3)
+
+class TravelogueResponse(BaseModel):
+    id: int
+    style_category: int | None = None 
+    created_at: datetime
+
+
+@router.get(
+    "/api/travelogue/all",
+    status_code=status.HTTP_200_OK,
+    response_model=List[TravelogueResponse],
+    summary="모든 여행기 튜플 확인",
+    description="현재 데이터베이스에 저장된 모든 여행기 튜플을 확인합니다"
+)
+async def get_travelogue(db: db_dependency):
+    return db.query(Travelogue).all()
+
+
+@router.get(
+    "/api/travelogue/{travelogue_id}",
+    status_code=status.HTTP_200_OK,
+    response_model=TravelogueResponse,
+    summary="특정 id 여행기 튜플 확인",
+    description="현재 데이터베이스에 저장된 특정 id 여행기 튜플을 확인합니다"
+)
+async def get_travelogue(travelogue_id: int, db: db_dependency):
+    db_travelogue = db.query(Travelogue).filter(Travelogue.id == travelogue_id).first()
+    if not db_travelogue:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail={"error": "Travelogue not found"})
+    return db_travelogue

--- a/api_sm.py
+++ b/api_sm.py
@@ -54,3 +54,18 @@ async def get_travelogue(travelogue_id: int, db: db_dependency):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                             detail={"error": "Travelogue not found"})
     return db_travelogue
+
+
+@router.post(
+    "/api/travelogue",
+    status_code=status.HTTP_201_CREATED,
+    response_model=TravelogueResponse,
+    summary="여행기 튜플 생성",
+    description="새로운 여행기 튜플을 생성합니다. style_category의 초기값은 Null로 생성됩니다."
+)
+async def create_travelogue(db: db_dependency):
+    db_travelogue = Travelogue()
+    db.add(db_travelogue)
+    db.commit()
+    db.refresh(db_travelogue)
+    return db_travelogue


### PR DESCRIPTION
## ✨ 작업 개요
- 여행기 튜플 확인 (GET) API 개발 - 모든 튜플, 특정 id 튜플에 따른 두 개의 API
- 여행기 튜플 생성 (POST) API 개발
- 여행기 튜플 수정 (PATCH) API 개발

---

## ✅ 주요 변경 사항
- `api_sm.py` 파일을 생성 및 API 개발 시작
- 여행기 튜플 확인/생성/수정 API, 총 4개의 API 개발 완료
- Endpoint, Request, Response, Error에 맞춰 API 개발

ex)
- `/travelogue` POST API 구현
- 이미지 URI 기반으로 GCP에서 데이터 수신
- travelogue 테이블에 데이터 저장 로직 추가

---

## 🧪 테스트 방법
- `localhost:8000/docs`를 활용해 API 테스트 수행
  - GET : 튜플 검색 테스트 완료
  - POST : 튜플 생성 이후 GET API를 활용해 검색 및 Default 값 삽입 확인 완료
  - PATCH : 튜플 수정 및 적용, 제약 조건 (1 <= style_category <= 3)에 따른 삽입 테스트 완료

---

## 💬 리뷰 요청 포인트
- 서비스의 로직에 맞는 API가 작성됐는지 확인 부탁드립니다.
  - Request, Response Value가 적절한가?
  - 예외처리가 적절한가?
  - Endpoint 설정이 적절한가?
- GET의 경우 서비스에 직접 적용되지는 않지만, 이후 테스트 및 분석을 위해 추가하였습니다.

close #10
