### PR TITLE
feat: 여행 목적/전체 질문 테이블 튜플 생성 API 추가 #16

### DIFF
--- a/api_sh.py
+++ b/api_sh.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from typing import Annotated, List
+from sqlalchemy.orm import Session
+from models import Purpose, TravelQuestionResponse
+from database import SessionLocal
+from starlette import status
+
+router = APIRouter()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+db_dependency = Annotated[Session, Depends(get_db)]
+
+class TravelPurposeQuestionRequest(BaseModel):
+    who: str = Field(..., description="누구와 가는지")
+    purpose_category: List[int] = Field(..., description="여행 목적 카테고리 리스트")
+
+class TravelPurposeQuestionResponse(BaseModel):
+    message: str
+    purpose_list: List[dict]
+    travel_question_response: dict
+
+
+@router.post(
+    "/api/travelogue/{travelogue_id}/question/total",
+    status_code=status.HTTP_201_CREATED,
+    response_model=TravelPurposeQuestionResponse,
+    summary="여행 목적/전체 질문 테이블 튜플 생성",
+    description="여행 목적과 전체 질문 테이블을 생성합니다."
+)
+async def create_purpose_and_question(
+    travelogue_id: int,
+    request: TravelPurposeQuestionRequest,
+    db: db_dependency
+):
+    purpose_list = []
+    
+    for category_id in request.purpose_category:
+        new_purpose = Purpose(
+            travelogue_id=travelogue_id,
+            purpose_category=category_id
+        )
+        db.add(new_purpose)
+        db.flush()
+        purpose_list.append({
+            "id": new_purpose.id,
+            "travelogue_id": new_purpose.travelogue_id,
+            "purpose_category": new_purpose.purpose_category
+        })
+    
+    new_question_response = TravelQuestionResponse(
+        travelogue_id=travelogue_id,
+        who=request.who
+    )
+    db.add(new_question_response)
+    db.flush()
+    
+    db.commit()
+
+    return {
+        "message": "success",
+        "purpose_list": purpose_list,
+        "travel_question_response": {
+            "id": new_question_response.id,
+            "travelogue_id": new_question_response.travelogue_id,
+            "who": new_question_response.who
+        }
+    }

--- a/api_sh.py
+++ b/api_sh.py
@@ -1,8 +1,9 @@
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, conlist, conint
 from typing import Annotated, List
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
-from models import Purpose, TravelQuestionResponse
+from models import Purpose, TravelQuestionResponse, Travelogue
 from database import SessionLocal
 from starlette import status
 
@@ -18,14 +19,12 @@ def get_db():
 db_dependency = Annotated[Session, Depends(get_db)]
 
 class TravelPurposeQuestionRequest(BaseModel):
-    who: str = Field(..., description="누구와 가는지")
-    purpose_category: List[int] = Field(..., description="여행 목적 카테고리 리스트")
+    who: conlist(conint(ge=1, le=6), min_length=1, max_length=6)
+    purpose_category: conlist(conint(ge=1, le=4), min_length=1, max_length=4)
 
 class TravelPurposeQuestionResponse(BaseModel):
-    message: str
     purpose_list: List[dict]
-    travel_question_response: dict
-
+    travel_question_response: List[dict]
 
 @router.post(
     "/api/travelogue/{travelogue_id}/question/total",
@@ -39,36 +38,59 @@ async def create_purpose_and_question(
     request: TravelPurposeQuestionRequest,
     db: db_dependency
 ):
-    purpose_list = []
-    
-    for category_id in request.purpose_category:
-        new_purpose = Purpose(
-            travelogue_id=travelogue_id,
-            purpose_category=category_id
+    travelogue = db.get(Travelogue, travelogue_id)
+    if not travelogue:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Travelogue ID {travelogue_id} not found"
         )
-        db.add(new_purpose)
-        db.flush()
-        purpose_list.append({
-            "id": new_purpose.id,
-            "travelogue_id": new_purpose.travelogue_id,
-            "purpose_category": new_purpose.purpose_category
-        })
-    
-    new_question_response = TravelQuestionResponse(
-        travelogue_id=travelogue_id,
-        who=request.who
-    )
-    db.add(new_question_response)
-    db.flush()
-    
-    db.commit()
 
-    return {
-        "message": "success",
-        "purpose_list": purpose_list,
-        "travel_question_response": {
-            "id": new_question_response.id,
-            "travelogue_id": new_question_response.travelogue_id,
-            "who": new_question_response.who
+    purpose_list = []
+    question_list = []
+
+    try:
+        for category_id in request.purpose_category:
+            new_purpose = Purpose(
+                travelogue_id=travelogue_id,
+                purpose_category=category_id
+            )
+            db.add(new_purpose)
+            db.flush()
+            purpose_list.append({
+                "id": new_purpose.id,
+                "travelogue_id": new_purpose.travelogue_id,
+                "purpose_category": new_purpose.purpose_category
+            })
+
+        for who_id in request.who:
+            new_question = TravelQuestionResponse(
+                travelogue_id=travelogue_id,
+                who=str(who_id)
+            )
+            db.add(new_question)
+            db.flush()
+            question_list.append({
+                "id": new_question.id,
+                "travelogue_id": new_question.travelogue_id,
+                "who": new_question.who
+            })
+
+        db.commit()
+
+        return {
+            "purpose_list": purpose_list,
+            "travel_question_response": question_list
         }
-    }
+
+    except IntegrityError as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Database constraint violated"
+        )
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e)
+        )


### PR DESCRIPTION
## ✨ 작업 개요

- 여행 목적/전체 질문 테이블 튜플 생성 API 개발

---

## ✅ 주요 변경 사항

- 여행 목적/전체질문 튜플 POST API 구현
- travelogue_id에 따라 purpose 테이블에 다중 목적 튜플 생성
- travelogue_id, who 값을 기반으로 travel_question_response 테이블에 단일 질문 튜플 생성

---

## 🧪 테스트 방법

- localhost:8000/docs를 활용해 API 테스트 수행
  - travelogue_id, who, purpose_catrgory 요청시 튜플 생성 확인

---

## 💬 리뷰 요청 포인트
- DB에 누락되는 값 없이 잘 들어가는지
- 튜플 생성 목록 맞는지

close #16 