### PR TITLE
[기능추가][API] 메타데이터 테이블의 튜플에 데이터를 삽입하기 위한 API 개발

### DIFF
--- a/api_sm.py
+++ b/api_sm.py
@@ -256,3 +256,33 @@ async def get_none_metadata_image(db: db_dependency, travelogue_id: int):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,  
             detail=f"Unexpected error: {str(e)}"
         )
+    
+
+
+class MetadataUpdate(BaseModel):
+    created_at: datetime
+    location: str
+
+
+@router.patch(
+    "/api/image/{image_id}/metadata",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="메타데이터 튜플 수정",
+    description="지정된 메타데이터의 created_at, location을 업데이트합니다."
+)
+async def update_metadata(db: db_dependency, update: MetadataUpdate, image_id: int):
+    db_metadata = db.query(Metadata).filter(Metadata.image_id == image_id).first()
+    if not db_metadata:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail={"error": "Metadata not found"})
+    db_metadata.created_at = update.created_at
+    db_metadata.location = update.location
+    try:
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error: {str(e)}"
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## ✨ 작업 개요
- 메타데이터 테이블의 튜플에 데이터를 삽입하기 위한 API 개발

---

## ✅ 주요 변경 사항
- `metadata` 테이블의 튜플에 입력된 데이터를 삽입하도록 PATCH API 개발

---

## 🧪 테스트 방법
- 로컬에서 API 작동 확인
  - 입력값에 따라 올바르게 튜플의 값이 바뀌는 것을 확인
<img src="https://github.com/user-attachments/assets/724df938-e653-477f-a3cb-916c5f7235f5" width=300>

---

## 💬 리뷰 요청 포인트
- API가 올바르게 작동 하는가?
- 추가적인 오류가 발생할 부분이 존재하는가?

close #23 