### PR TITLE
[기능추가][API] 여행기 검토 및 수정 API 개발

### DIFF
--- a/api_sm.py
+++ b/api_sm.py
@@ -286,3 +286,31 @@ async def update_metadata(db: db_dependency, update: MetadataUpdate, image_id: i
             detail=f"Unexpected error: {str(e)}"
     )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+
+class FinalRequest(BaseModel):
+    final: str
+
+
+@router.patch(
+    "/api/image/{image_id}/correction",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="여행기 final 필드 수정",
+    description="image_id에 해당하는 튜플의 final 값을 저장합니다."
+)
+async def update_final(db: db_dependency, image_id: int, final: FinalRequest):
+    db_image = db.query(Image).filter(Image.id == image_id).first()
+    if not db_image:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail={"error": "image not found"})
+    db_image.final = final.final
+    try:
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error: {str(e)}"
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## ✨ 작업 개요
- 사용자가 검토 및 수정한 여행기를 image 테이블의 final 필드에 저장하는 API 개발

---

## ✅ 주요 변경 사항
- 사용자가 검토 및 수정한 여행기를 image 테이블의 final 필드에 저장하는 API 개발

---

## 🧪 테스트 방법
- 로컬에서 API 작동 확인
  - 입력값에 따라 올바르게 튜플의 값이 바뀌는 것을 확인

<img src="https://github.com/user-attachments/assets/3a8c30b9-8bbe-4a26-abda-2ef61a742651" width=500>

---

## 💬 리뷰 요청 포인트
- API가 올바르게 작동하는가?
- 추가적인 오류가 발생하는가?

close #26 
