### PR TITLE
fix: 사전 질문 응답 저장 API Method 오류 수정 #27

### DIFF
--- a/api_sm.py
+++ b/api_sm.py
@@ -344,7 +344,7 @@ class EachImageQuestionResponse(BaseModel):
     emotion_list: List[EmotionResponse]
 
 
-@router.patch(
+@router.post(
     "/api/image/{image_id}/question",
     response_model=EachImageQuestionResponse,
     status_code=status.HTTP_201_CREATED,


### PR DESCRIPTION
## ✨ 작업 개요
- 사전 질문 응답 저장 API Method 오류 수정

---

## ✅ 주요 변경 사항
- 사전 질문 응답 저장 API Method가 `PATCH`로 돼 있었음
- 동작에 적합한 Method는 `POST`, ISSUE에도 `POST`로 적혀 있으므로 `POST`로 변경

---

## 🧪 테스트 방법

---

## 💬 리뷰 요청 포인트
