### PR TITLE
[기능추가/수정][API] 여행기 (draft) 반환 API 개발 / is_in_travelogue가 true인 image url 반환 API 수정

### DIFF
--- a/api_sm.py
+++ b/api_sm.py
@@ -397,7 +397,7 @@ class DraftResponse(BaseModel):
     summary="여행기 초안 반환",
     description="travelogue_id에 대한 draft를 시간 순으로 정렬해 반환합니다."
 )
-async def execute_travelogue_generation(db: db_dependency, travelogue_id: int):
+async def get_travelogue_draft(db: db_dependency, travelogue_id: int):
     mappings = db.query(TravelogueImage).filter(TravelogueImage.travelogue_id == travelogue_id).all()
     if not mappings:
         raise HTTPException(  

--- a/api_sm.py
+++ b/api_sm.py
@@ -171,19 +171,18 @@ async def create_image(db:db_dependency, travelogue_id: int = Form(...), images:
 
 
 class ActivatedResponse(BaseModel):
-    id: int
+    image_id: int
     image_url: str
-    draft: str | None = None
 
 class ActivatedListResponse(BaseModel):
-    image_draft_list: List[ActivatedResponse]
+    image_list: List[ActivatedResponse]
 
 @router.get(
     "/api/image/{travelogue_id}/activated",
     response_model=ActivatedListResponse,
     status_code=status.HTTP_200_OK,
-    summary="is_in_travelogue가 true인 image url 및 draft 확인",
-    description="travelogue_id에 해당하는 image 튜플 중 is_in_travelogue가 true인 image의 Signed URL과 draft를 확인합니다."
+    summary="is_in_travelogue가 true인 image url 반환",
+    description="travelogue_id에 해당하는 image 튜플 중 is_in_travelogue가 true인 image의 Signed UR을 반환합니다."
 )
 async def get_used_image_url_and_draft(db: db_dependency, travelogue_id: int):
     mappings = db.query(TravelogueImage).filter(TravelogueImage.travelogue_id == travelogue_id).all()
@@ -205,11 +204,10 @@ async def get_used_image_url_and_draft(db: db_dependency, travelogue_id: int):
             signed_url = generate_signed_url(image.uri)
 
             result.append({
-                "id": image.id,
-                "image_url": signed_url,
-                "draft": image.draft
+                "image_id": image.id,
+                "image_url": signed_url
             })
-        return {"image_draft_list": result}
+        return {"image_list": result}
     except Exception as e:
         raise HTTPException(  
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,  

--- a/api_sm.py
+++ b/api_sm.py
@@ -397,7 +397,7 @@ class DraftResponse(BaseModel):
     summary="여행기 초안 반환",
     description="travelogue_id에 대한 draft를 시간 순으로 정렬해 반환합니다."
 )
-async def get_travelogue_draft(db: db_dependency, travelogue_id: int):
+async def get_time_ordered_travelogue_draft(db: db_dependency, travelogue_id: int):
     mappings = db.query(TravelogueImage).filter(TravelogueImage.travelogue_id == travelogue_id).all()
     if not mappings:
         raise HTTPException(  
@@ -422,7 +422,6 @@ async def get_travelogue_draft(db: db_dependency, travelogue_id: int):
 
         return {"draft_list": [{"image_id": image.id, "draft": image.draft} for image in sorted_images]}
     except Exception as e:
-        db.rollback()
         raise HTTPException(  
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,  
             detail=f"Unexpected error: {str(e)}"


### PR DESCRIPTION
## ✨ 작업 개요
- 여행기 (draft) 반환 API (GET) 개발
- is_in_travelogue가 true인 image url만 반환하도록 변경

---

## ✅ 주요 변경 사항
- 여행기 (draft) 반환 API (GET) 개발
  - `metadata`의 `created_at`을 참고하여 시간 순으로 `image_id`와 `draft`를 반환
- `is_in_travelogue`가 `true`인 `image url`만 반환하도록 변경
  - 원래 `image_id` `image_url` `draft`를 반환했지만, draft는 다른 API를 통해 반환하므로 제거

---

## 🧪 테스트 방법
- 로컬 환경에서 API 테스트 수행
  - 시간 순으로 올바르게 정렬되어 반환되는 것을 확인
  - 원래부터 시간순으로 입력된 값이기에 `asc`를 `desc`로 변경했을 때, 역순인 것을 확인
<img src="https://github.com/user-attachments/assets/209fa7c1-1c46-460f-aa94-3a270a5ff7b7" width=300>
<img src="https://github.com/user-attachments/assets/dfa6a2f6-8abd-4bcb-8883-ee6882949b0b" width=500>

---

## 💬 리뷰 요청 포인트
- 추가적인 오류가 발생할 수 있는지?
- 명세서에 적힌대로 API가 동작하는지?

close #41 
