### PR TITLE
[기능개선][API] 이미지 업로드 API 속도 개선

### DIFF
--- a/api_sm.py
+++ b/api_sm.py
@@ -118,7 +118,7 @@ class CombinedResponse(BaseModel):
     summary="이미지 튜플 생성 및 업로드",
     description="입력된 이미지를 기반으로 튜플을 생성하고, GCP Storage에 업로드합니다."
 )
-async def create_image(db:db_dependency, travelogue_id: int = Form(...), images: List[UploadFile] = File(...)):
+async def create_image(db: db_dependency, travelogue_id: int = Form(...), images: List[UploadFile] = File(...)):
     travelogue = db.get(Travelogue, travelogue_id)
     if not travelogue:
         raise HTTPException(
@@ -132,7 +132,7 @@ async def create_image(db:db_dependency, travelogue_id: int = Form(...), images:
         for i, image in enumerate(images, start=1):
             file_name = f"{travelogue_id}_{i}.jpg"
             file_bytes = await image.read()
-            uri = upload_image_to_gcs(file_bytes, file_name, content_type=image.content_type)
+            uri = await upload_image_to_gcs(file_bytes, file_name, content_type=image.content_type)
             uploaded_files.append(file_name)
 
             image = Image(


### PR DESCRIPTION
## ✨ 작업 개요
- 이미지 업로드 API 속도 개선

---

## ✅ 주요 변경 사항
- `gcs_utils`의 `upload_image_to_gcs` 함수를 비동기 함수로 변경 및 asyncio 적용
  - GCP는 기본적으로 비동기 처리를 지원하지 않아 asyncio 라이브러리를 활용해 처리
  - 세마포어를 활용해 서버 과부화 방지 (동시 업로드 수를 최대 5로 설정)
- 이미지 업로드 API 에서 await를 사용해 비동기 함수 호출

---

## 🧪 테스트 방법
- 로컬 환경에서 이미지 업로드 API 테스트 수행
- 14장 기준, 3초 소요 -> 더 많은 사진을 업로드 하더라도 빠르게 처리가 될 것

---

## 💬 리뷰 요청 포인트
- 비동기 처리가 올바르게 작동하는지?
- 비동기 처리로 변경하면서 추가적인 오류가 존재하는지?
