### PR TITLE
feat: 여행기 이미지 시간순 정렬 API 개발 / 이미지 2차 선별 수정

### DIFF
--- a/api_sh.py
+++ b/api_sh.py
@@ -128,6 +128,9 @@ class CaptionMetadataResponse(BaseModel):
     caption_list: List[CaptionResponse]
     metadata_list: List[MetadataResponse]
 
+class ImageIdsRequest(BaseModel):
+    image_ids: Optional[List[int]] = None
+
 
 def convert_to_degrees(value):
     d = float(value.values[0].num) / float(value.values[0].den)
@@ -159,9 +162,10 @@ def reverse_geocode(lat: float, lon: float) -> str:
 )
 async def select_second_image(
     travelogue_id: int,
-    image_ids: Optional[List[int]] = Query(None),
+    request: ImageIdsRequest,
     db: Session = Depends(get_db)
 ):
+    image_ids = request.image_ids
     caption_list = []
     metadata_list = []
 
@@ -454,41 +458,45 @@ async def share_travelogue_pdf(travelogue_id: int):
     return {"share_url": share_url}
 
 
-class ImageOrderRequest(BaseModel):
-    image_ids: List[int]
-
 class ImageOrderResponse(BaseModel):
     image_ids: List[int]
 
-@router.post(
-    "/api/travelogue/images/timeorder",
+@router.get(
+    "/api/images/timeorder",
     status_code=status.HTTP_200_OK,
     response_model=ImageOrderResponse,
     summary="이미지 촬영시간순 정렬",
     description="image_ids 리스트를 촬영시간순으로 정렬해 반환합니다."
 )
 async def order_images_by_time(
-    request: ImageOrderRequest,
+    image_ids: List[int] = Query(..., description="정렬할 이미지 id 리스트"),
     db: Session = Depends(get_db)
 ):
+    try:
+        images = db.query(Image).filter(Image.id.in_(image_ids)).all()
+        if not images:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="지정한 이미지를 찾을 수 없습니다."
+            )
+        
+        created_at_map = {}
+        for img in images:
+            try:
+                created_at_map[img.id] = extract_created_at_from_gcs(img.uri)
+            except Exception:
+                created_at_map[img.id] = None
 
-    images = db.query(Image).filter(Image.id.in_(request.image_ids)).all()
-    if not images:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="지정한 이미지를 찾을 수 없습니다."
+        ordered_ids = sorted(
+            image_ids,
+            key=lambda x: (created_at_map.get(x) is None, created_at_map.get(x))
         )
-    
-    created_at_map = {}
-    for img in images:
-        try:
-            created_at_map[img.id] = extract_created_at_from_gcs(img.uri)
-        except Exception:
-            created_at_map[img.id] = None
 
-    ordered_ids = sorted(
-        request.image_ids,
-        key=lambda x: (created_at_map.get(x) is None, created_at_map.get(x))
-    )
-
-    return {"image_ids": ordered_ids}
+        return {"image_ids": ordered_ids}
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"서버 내부 오류: {str(e)}"
+        )


### PR DESCRIPTION
## ✨ 작업 개요
- 프론트엔드에서 받은 image_ids 리스트의 이미지를 촬영시간(created_at) 기준으로 정렬해 반환하는 API 개발

---

## ✅ 주요 변경 사항
- pdf 저장에서와 같은 방식을 사용해 이미지 시간순 정렬

---

## 🧪 테스트 방법
- API 실행 후 DB에 입력된 정보로 시간순 정렬 된 것 확인
![image](https://github.com/user-attachments/assets/67913cf4-00c6-42fd-91d9-01cf21c3a0ba)
![image](https://github.com/user-attachments/assets/33256518-98e5-4fc5-9993-4e8716ddef78)
![image](https://github.com/user-attachments/assets/aeb7ea09-108e-45ff-9a18-f27fb1d189ee)



---

## 💬 리뷰 요청 포인트
- 이슈와 맞게 작성되었는지

close #64 